### PR TITLE
Add 4.9.x branch to source

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,11 +6,11 @@ site:
 content:
   sources:
     - url: https://github.com/FatihBozik/mirket-developer-guide.git
-      branches: [v4.8.x]
+      branches: [v4.8.x, v4.9.x]
       start_path: docs
       edit_url: false
     - url: https://github.com/FatihBozik/mirket-guide.git
-      branches: [ v4.8.x ]
+      branches: [v4.8.x]
       start_path: docs
       edit_url: false
 asciidoc:


### PR DESCRIPTION
Resolves : MIRKET-664

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Documentation can now be sourced from both v4.8.x and v4.9.x branches.
  
- **Bug Fixes**
	- Corrected formatting of branch specification for the second content source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->